### PR TITLE
feat: Add email alias/identity selection support to send_email tool

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -120,10 +120,14 @@ server.setRequestHandler(ToolsListRequestSchema, async () => {
       },
       {
         name: 'send_email',
-        description: 'Send a new email',
+        description: 'Send a new email. Supports sending from different identities/aliases when "from" parameter is specified.',
         inputSchema: {
           type: 'object',
           properties: {
+            from: { 
+              type: 'string', 
+              description: 'From email address (must be a valid alias/identity). Optional - if not specified, uses the default account email. Available identities can be found by checking your Fastmail aliases.' 
+            },
             to: {
               type: 'array',
               items: {


### PR DESCRIPTION
## Summary

Adds support for sending emails from different configured aliases/identities by implementing an optional `from` parameter in the `send_email` tool.

Closes #2

## Changes Made

- **Added optional `from` parameter** to `send_email` tool schema with clear documentation
- **Implemented `getIdentityByEmail()` method** to lookup identities by email address
- **Enhanced `sendEmail()` method** to accept and use custom from addresses
- **Maintained full backward compatibility** - defaults to primary account email when `from` not specified
- **Added comprehensive error handling** for invalid identities with helpful error messages listing available options
- **Updated tool description** to document the new identity selection capability

## Technical Details

The implementation:
1. Queries available identities via JMAP `Identity/get`
2. Finds the matching identity for the specified `from` email address
3. Uses that identity when submitting the email via `EmailSubmission/set`
4. Falls back to primary identity when no `from` parameter is provided

## Testing

Tested in Claude Desktop using a local MCP server run from a git checkout of the fork:

- ✅ Verified sending emails with custom alias addresses
- ✅ Verified default behavior preserved when no `from` specified
- ✅ Verified error handling for invalid email addresses
- ✅ Confirmed backward compatibility with existing usage
- ✅ Tested identity lookup and selection mechanism
- ✅ Validated proper JMAP integration with Fastmail aliases

## Example Usage

```json
{
  "method": "tools/call", 
  "params": {
    "name": "send_email",
    "arguments": {
      "from": "business@example.com",
      "to": [{"email": "client@company.com"}],
      "subject": "Business Communication",
      "textBody": "Email sent from business alias"
    }
  }
}
```

This enhancement enables users to send emails from their configured Fastmail aliases rather than being limited to the primary account email address.